### PR TITLE
add support for enums and typedef enum and struct declaration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/sunshine-protocol/dart-bindgen"
 license-file = "LICENSE"
 
 [dependencies]
-clang = "0.24.0"
+clang = { version = "0.24.0", features=["clang_3_7"] }
 thiserror = "^1.0"
 log = "^0.4"
 # CLI Deps

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -1,0 +1,68 @@
+use crate::dart_source_writer::{DartSourceWriter, ImportedUri};
+use std::io::{self, Write};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Enum {
+    documentation: Option<String>,
+    name: String,
+    fields: Vec<EnumField>,
+}
+
+impl Enum {
+    pub(crate) fn new(
+        name: String,
+        documentation: Option<String>,
+        fields: Vec<EnumField>,
+    ) -> Self {
+        Self {
+            documentation,
+            name,
+            fields,
+        }
+    }
+}
+
+impl crate::Element for Enum {
+    #[inline(always)]
+    fn name(&self) -> &str { &self.name }
+
+    #[inline(always)]
+    fn documentation(&self) -> Option<&str> { self.documentation.as_deref() }
+
+    fn generate_source(&self, w: &mut DartSourceWriter) -> io::Result<()> {
+        let mut ffi = ImportedUri::new(String::from("package:ffi/ffi.dart"));
+        ffi.with_prefix(String::from("ffi"));
+        w.import(ffi);
+        writeln!(w)?;
+        if let Some(ref docs) = self.documentation {
+            let docs = docs
+                .split('\n')
+                .map(|c| format!("/// {}", c))
+                .collect::<Vec<_>>()
+                .join("\n");
+            writeln!(w, "{}", docs)?;
+        } else {
+            writeln!(w, "/// C enum `{}`.", self.name)?;
+        }
+        writeln!(w, "abstract class {} {{", self.name)?;
+
+        for EnumField { name, value } in &self.fields {
+            writeln!(w, "  static const int {} = {};", name, value)?;
+        }
+
+        writeln!(w, "}}")?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct EnumField {
+    name: String,
+    value: u64,
+}
+
+impl EnumField {
+    pub(crate) const fn new(name: String, value: u64) -> Self {
+        Self { name, value }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,6 +26,14 @@ pub enum CodegenError {
     UnnamedStructField,
     #[error("Unknown type for struct field `a` at ")]
     UnknownStructFieldType,
+    #[error("Found Enum without name at ")]
+    UnnamedEnum,
+    #[error("Unknown name for enum field `a` at ")]
+    UnnamedEnumField,
+    #[error("Unknown constant value for enum field `a` at ")]
+    UnknownEnumFieldConstantValue,
+    #[error("An anonymous entity found at ")]
+    AnonymousEntity,
 }
 
 impl From<String> for CodegenError {

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -1,0 +1,34 @@
+use dart_bindgen::{config::*, Codegen};
+use insta::assert_snapshot;
+use log::LevelFilter;
+use simplelog::{TermLogger, TerminalMode};
+use std::io::Cursor;
+
+#[test]
+fn test_enum() {
+    TermLogger::init(
+        LevelFilter::Debug,
+        Default::default(),
+        TerminalMode::Mixed,
+    )
+    .unwrap();
+    let config = DynamicLibraryConfig {
+        ios: DynamicLibraryCreationMode::Executable.into(),
+        android: DynamicLibraryCreationMode::open("libenum.so").into(),
+        windows: DynamicLibraryCreationMode::open("enum.dll").into(),
+        ..Default::default()
+    };
+    let bindings = Codegen::builder()
+        .with_src_header("tests/headers/enum.h")
+        .with_lib_name("libenum")
+        .with_config(config)
+        .build()
+        .unwrap()
+        .generate()
+        .unwrap();
+
+    let mut out = Cursor::new(Vec::new());
+    bindings.write(&mut out).unwrap();
+    let out = String::from_utf8(out.into_inner()).unwrap();
+    assert_snapshot!(out);
+}

--- a/tests/headers/enum.h
+++ b/tests/headers/enum.h
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum NormalEnum {
+    NormalValueA,
+    NormalValueB,
+    NormalValueC = 3,
+    NormalValueD,
+}
+
+typedef enum {
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+} DefaultEnum;
+
+typedef enum {
+  G,
+  H = 20,
+  J = 55,
+  K,
+  L,
+  M,
+} ValuedEnum;
+

--- a/tests/headers/struct.h
+++ b/tests/headers/struct.h
@@ -1,0 +1,17 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct NormalStruct {
+    int a;
+    char* b;
+}
+
+typedef struct {
+    int a;
+    int b;
+    char* c;
+    long long d;
+} TypedStruct;
+

--- a/tests/snapshots/r#enum__enum.snap
+++ b/tests/snapshots/r#enum__enum.snap
@@ -1,0 +1,49 @@
+---
+source: tests/enum.rs
+expression: out
+---
+/// bindings for `libenum`
+
+import 'dart:ffi';
+import 'dart:io';
+import 'package:ffi/ffi.dart' as ffi;
+
+// ignore_for_file: unused_import, camel_case_types, non_constant_identifier_names
+final DynamicLibrary _dl = _open();
+/// Reference to the Dynamic Library, it should be only used for low-level access
+final DynamicLibrary dl = _dl;
+DynamicLibrary _open() {
+  if (Platform.isWindows) return DynamicLibrary.open('enum.dll');
+  if (Platform.isAndroid) return DynamicLibrary.open('libenum.so');
+  if (Platform.isIOS) return DynamicLibrary.executable();
+  throw UnsupportedError('This platform is not supported.');
+}
+
+/// C enum `DefaultEnum`.
+abstract class DefaultEnum {
+  static const int A = 0;
+  static const int B = 1;
+  static const int C = 2;
+  static const int D = 3;
+  static const int E = 4;
+  static const int F = 5;
+}
+
+/// C enum `NormalEnum`.
+abstract class NormalEnum {
+  static const int NormalValueA = 0;
+  static const int NormalValueB = 1;
+  static const int NormalValueC = 3;
+  static const int NormalValueD = 4;
+}
+
+/// C enum `ValuedEnum`.
+abstract class ValuedEnum {
+  static const int G = 0;
+  static const int H = 20;
+  static const int J = 55;
+  static const int K = 56;
+  static const int L = 57;
+  static const int M = 58;
+}
+

--- a/tests/snapshots/r#struct__enum.snap
+++ b/tests/snapshots/r#struct__enum.snap
@@ -1,0 +1,59 @@
+---
+source: tests/struct.rs
+expression: out
+---
+/// bindings for `libstruct`
+
+import 'dart:ffi';
+import 'dart:io';
+import 'package:ffi/ffi.dart' as ffi;
+
+// ignore_for_file: unused_import, camel_case_types, non_constant_identifier_names
+final DynamicLibrary _dl = _open();
+/// Reference to the Dynamic Library, it should be only used for low-level access
+final DynamicLibrary dl = _dl;
+DynamicLibrary _open() {
+  if (Platform.isWindows) return DynamicLibrary.open('struct.dll');
+  if (Platform.isAndroid) return DynamicLibrary.open('libstruct.so');
+  if (Platform.isIOS) return DynamicLibrary.executable();
+  throw UnsupportedError('This platform is not supported.');
+}
+
+/// C struct `NormalStruct`.
+class NormalStruct extends Struct {
+  
+  @Int32()
+  int a;
+  Pointer<ffi.Utf8> b;
+  static Pointer<NormalStruct> allocate() {
+    return ffi.allocate<NormalStruct>();
+  }
+
+
+  static NormalStruct from(int ptr) {
+    return Pointer<NormalStruct>.fromAddress(ptr).ref;
+  }
+
+}
+
+/// C struct `TypedStruct`.
+class TypedStruct extends Struct {
+  
+  @Int32()
+  int a;
+  @Int32()
+  int b;
+  Pointer<ffi.Utf8> c;
+  @Int64()
+  int d;
+  static Pointer<TypedStruct> allocate() {
+    return ffi.allocate<TypedStruct>();
+  }
+
+
+  static TypedStruct from(int ptr) {
+    return Pointer<TypedStruct>.fromAddress(ptr).ref;
+  }
+
+}
+

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -1,0 +1,34 @@
+use dart_bindgen::{config::*, Codegen};
+use insta::assert_snapshot;
+use log::LevelFilter;
+use simplelog::{TermLogger, TerminalMode};
+use std::io::Cursor;
+
+#[test]
+fn test_enum() {
+    TermLogger::init(
+        LevelFilter::Debug,
+        Default::default(),
+        TerminalMode::Mixed,
+    )
+    .unwrap();
+    let config = DynamicLibraryConfig {
+        ios: DynamicLibraryCreationMode::Executable.into(),
+        android: DynamicLibraryCreationMode::open("libstruct.so").into(),
+        windows: DynamicLibraryCreationMode::open("struct.dll").into(),
+        ..Default::default()
+    };
+    let bindings = Codegen::builder()
+        .with_src_header("tests/headers/struct.h")
+        .with_lib_name("libstruct")
+        .with_config(config)
+        .build()
+        .unwrap()
+        .generate()
+        .unwrap();
+
+    let mut out = Cursor::new(Vec::new());
+    bindings.write(&mut out).unwrap();
+    let out = String::from_utf8(out.into_inner()).unwrap();
+    assert_snapshot!(out);
+}


### PR DESCRIPTION
```C
enum A {
    a,
    b,
}
typedef enum {
    c,
    d
} B;
typedef struct {
    int e;
    char* f;
} C;
```

Can all be parsed now.

C++ `enum class` cannot be parsed correctly for now

Used `clang_3_7` feature for `is_anonymous`

The way we handled enum in abstract class is the best way for now, check dart-lang/ffigen#114

can you review? @shekohex