### PR TITLE
deprecate dart-bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dart-bindgen"
-version = "0.1.8"
+version = "0.1.8-deprecated"
 authors = ["Sunshine Foundation Developers", "Shady Khalifa <shekohex@gmail.com>"]
 edition = "2018"
 description = "A tool for generating Dart FFI bindings to C Header file."
@@ -35,4 +35,4 @@ deafult = []
 cli = ["argh", "pretty_env_logger", "anyhow"]
 
 [badges]
-maintenance = { status = "actively-developed" }
+maintenance = { status = "deprecated" }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 <br />
 
+<h3 align="center">⚠️ This crate is deprecated and 🚧 unmaintained 🚧 for now, please prefer <a href="https://github.com/dart-lang/ffigen">ffigen</a> from the dart team.</h3>
+
+<br />
+
 <div align="center">
   <a href="https://github.com/sunshine-protocol/dart-bindgen">
     <img src="https://github.com/sunshine-protocol/dart-bindgen/workflows/Snapshot%20Testing/badge.svg"


### PR DESCRIPTION
Hello everyone, This PR is to adding a deprecation note to this repo and deprecate `dart-bindgen` in favor of [ffigen](https://github.com/dart-lang/ffigen) from the dart team.
Since it will be better to get official support from them, and new updates.